### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "element-ui": "^2.3.2",
     "http-proxy-middleware": "^0.18.0",
     "js-md5": "^0.7.3",
-    "npm": "^6.9.0",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"


### PR DESCRIPTION

Hello cy1096243489!

It seems like you have npm as one of your (dev-) dependency in vue-ele2.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
